### PR TITLE
add missing packages to the minimal requirements example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ sudo update-java-alternatives -s adoptopenjdk-11-jre-openj9
 ```bash
 # update and install support for https:// sources if not already installed
 [[ ! -f /usr/lib/apt/methods/https ]] && sudo apt-get update && sudo apt-get install apt-transport-https
+
+# install requirements for apt update and apt-key when missing
+[[ ! -f /etc/ssl/certs/ca-certificates.crt ]] && sudo apt-get install ca-certificates
+[[ ! -f /usr/bin/dirmngr ]] && sudo apt-get install dirmngr
+[[ ! -f /usr/bin/gnupg ]] && sudo apt-get install gnupg
+
 # add my key to trusted APT keys 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A66C5D02
 # add the package repo to sources 


### PR DESCRIPTION
When running a bare-minimum debian like the stretch-slim image from
docker.hub, some requirements are missing to complete the installation.

apt-key will fail to work without a gpg implementation and the dirmngr
for tmp-dir creation installed. ca-certificates are not included, which
will make any `apt update` fail with "The repository '<...> stable
Release' does not have a Release file."

I tried to harmonize the addition with the checks already present.